### PR TITLE
process.py: Increase bitbake timeout to 600s

### DIFF
--- a/lib/bb/server/process.py
+++ b/lib/bb/server/process.py
@@ -326,8 +326,10 @@ class ServerCommunicator():
 
     def runCommand(self, command):
         self.connection.send(command)
-        if not self.recv.poll(30):
-            raise ProcessTimeout("Timeout while waiting for a reply from the bitbake server")
+        if not self.recv.poll(300):
+            logger.info("No reply from server in 300s")
+            if not self.recv.poll(300):
+                raise ProcessTimeout("Timeout while waiting for a reply from the bitbake server (600s)")
         return self.recv.get()
 
     def updateFeatureSet(self, featureset):


### PR DESCRIPTION
Fix for the intermittent "Unable to connect to bitbake server ..." error.

Cherry picked from [dunfell branch](https://github.com/ni/bitbake/commit/46a17ccef432a840de2768b88646efdb880a6392#diff-8d4104ed1ef05e2989da85f3fb0b904cc801d92162d7331c3066551cd2cc94b8)

@ni/rtos 