### PR TITLE
[sumo] Handle and warn github SRC_URIs which use the git protocol

### DIFF
--- a/lib/bb/fetch2/git.py
+++ b/lib/bb/fetch2/git.py
@@ -156,6 +156,7 @@ class Git(FetchMethod):
             # github stopped supporting git protocol
             # https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git
             ud.proto = "https"
+            bb.warn("URL: %s uses git protocol which is no longer supported by github. Please change to ;protocol=https in the url." % ud.url)
 
         if not ud.proto in ('git', 'file', 'ssh', 'http', 'https', 'rsync'):
             raise bb.fetch2.ParameterError("Invalid protocol type", ud.url)

--- a/lib/bb/fetch2/git.py
+++ b/lib/bb/fetch2/git.py
@@ -152,6 +152,10 @@ class Git(FetchMethod):
             ud.proto = 'file'
         else:
             ud.proto = "git"
+        if ud.host == "github.com" and ud.proto == "git":
+            # github stopped supporting git protocol
+            # https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git
+            ud.proto = "https"
 
         if not ud.proto in ('git', 'file', 'ssh', 'http', 'https', 'rsync'):
             raise bb.fetch2.ParameterError("Invalid protocol type", ud.url)


### PR DESCRIPTION
Github is planning to shut off `git://` protocol access for all repositories in April. After that time, all recipes which use sources like `git://github.com/...` and *do not* use the `protocol=https` parameter will fail do_fetch.

This PR backports two commits from upstream bitbake. When bitbake determines that a source meets the above criteria it will now:
1. switch the protocol to `https` automatically
2. throw a `WARNING:` to the builder that the recipe URI needs to be updated.

# Testing
Building `nilrt/master/sumo` with these patches does not fail, but does throw ~244 unique recipe warnings from all the files in sumo which meet this criteria.

@ni/rtos 