### PR TITLE
fetch/git: Show warning for invalid github urls

### DIFF
--- a/lib/bb/fetch2/git.py
+++ b/lib/bb/fetch2/git.py
@@ -146,6 +146,7 @@ class Git(FetchMethod):
             # github stopped supporting git protocol
             # https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git
             ud.proto = "https"
+            bb.warn("URL: %s uses git protocol which is no longer supported by github. Please change to ;protocol=https in the url." % ud.url)
 
         if not ud.proto in ('git', 'file', 'ssh', 'http', 'https', 'rsync'):
             raise bb.fetch2.ParameterError("Invalid protocol type", ud.url)


### PR DESCRIPTION
On master, tell the users they need to update their urls for github.

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>
(cherry picked from commit 42526a402357e04794f4cb6f21ac18f562220a9b)
Signed-off-by: Alex Stewart <alex.stewart@ni.com>

@ni/rtos 