### PR TITLE
Merge latest upstream

### DIFF
--- a/lib/bb/tests/fetch.py
+++ b/lib/bb/tests/fetch.py
@@ -1335,7 +1335,7 @@ class FetchLatestVersionTest(FetcherTest):
         # combination version pattern
         ("sysprof", "git://gitlab.gnome.org/GNOME/sysprof.git;protocol=https;branch=master", "cd44ee6644c3641507fb53b8a2a69137f2971219", "")
             : "1.2.0",
-        ("u-boot-mkimage", "git://git.denx.de/u-boot.git;branch=master;protocol=git", "62c175fbb8a0f9a926c88294ea9f7e88eb898f6c", "")
+        ("u-boot-mkimage", "git://source.denx.de/u-boot/u-boot.git;branch=master;protocol=https", "62c175fbb8a0f9a926c88294ea9f7e88eb898f6c", "")
             : "2014.01",
         # version pattern "yyyymmdd"
         ("mobile-broadband-provider-info", "git://gitlab.gnome.org/GNOME/mobile-broadband-provider-info.git;protocol=https;branch=master", "4ed19e11c2975105b71b956440acdb25d46a347d", "")


### PR DESCRIPTION
This is a regular NILRT distro upstream merge with 2.0 upstream branch.
There were no merge conflicts.
[#AB2755009](https://dev.azure.com/ni/DevCentral/_workitems/edit/2755009/)

**Testing**

- [x]  bitbake packagefeed-ni-core
- [X] bitbake packagegroup-ni-desirable
- [X] bitbake package-index && bitbake nilrt-base-system-image
- [X] unpacked resulting nilrt-base-system-image-x64.tar on a VM and verified the target boots into runmode w/o problems.

**Note**

- maintainers please complete this merge manually (i.e. to avoid upstream hashes being changed by GH).

Signed-off by: Pratheeksha S N <pratheeksha.s.n@ni.com>